### PR TITLE
Use internal methods in create

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ class Service {
   }
 
   _create(data, params) {
-    return this.db().insert(data, this.id).then(rows => this.get(rows[0], params))
+    return this.db().insert(data, this.id).then(rows => this._get(rows[0], params))
       .catch(errorHandler);
   }
 


### PR DESCRIPTION
There's a call to .get in .create, changed it to use the internal method like 4f331cf46