### PR TITLE
Add error handling for mysql and mysql2 server errors

### DIFF
--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -3,7 +3,42 @@ import errors from 'feathers-errors';
 export default function errorHandler (error) {
   let feathersError = error;
 
-  // TODO (EK): Map PG, MySQL, Oracle, etc. errors
+  // TODO (EK): Map PG, Oracle, etc. errors
+
+  // NOTE: SQLState values from
+  // https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-error-sqlstates.html
+
+  if (error.sqlState && error.sqlState.length) {
+    // remove SQLSTATE marker (#) and pad/truncate SQLSTATE to 5 chars
+    let sqlState = ('00000' + error.sqlState.replace('#', '')).slice(-5);
+
+    switch (sqlState.slice(0, 2)) {
+      case '02':
+        feathersError = new errors.NotFound(error);
+        break;
+      case '28':
+        feathersError = new errors.Forbidden(error);
+        break;
+      case '08':
+      case '0A':
+      case '0K':
+        feathersError = new errors.Unavailable(error);
+        break;
+      case '20':
+      case '21':
+      case '22':
+      case '23':
+      case '24':
+      case '25':
+      case '40':
+      case '42':
+      case '70':
+        feathersError = new errors.BadRequestError(error);
+        break;
+      default:
+        feathersError = new errors.GeneralError(error);
+    }
+  }
 
   // NOTE (EK): Error codes taken from
   // https://www.sqlite.org/c3ref/c_abort.html


### PR DESCRIPTION
### Summary

This PR maps server errors from the **mysql** and **mysql2** drivers according to their `sqlState` property. A few notes/caveats:

- Server errors only, client errors don't have a `sqlState` prop
- I used SQLSTATE because the values are part of [SQL92](http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt)
- I figure this means other SQL implementations probably expose these values (research needed)
- I used the SQLite handler as a guide
