### PR TITLE
Initialize Database Table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - '4'
 sudo: false
 before_script:
+- unset NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR
 - npm install -g codeclimate-test-reporter
 after_script:
 - codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: node_js
 node_js:
   - node
-  - '7'
   - '6'
   - '4'
 sudo: false
 before_script:
-- npm i sqlite3 --build-from-source
 - npm install -g codeclimate-test-reporter
 after_script:
 - codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - '4'
 sudo: false
 before_script:
+- npm i sqlite3 --build-from-source
 - npm install -g codeclimate-test-reporter
 after_script:
 - codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 node_js:
   - node
+  - '7'
   - '6'
   - '4'
 sudo: false
 before_script:
-- unset NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR
 - npm install -g codeclimate-test-reporter
 after_script:
 - codeclimate-test-reporter < coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ todos
   .init({}, function(table) {
 
     //define your schema
-    debug(`created ${table} table`);
+    console.log(`created ${table._tableName} table`);
     table.increments('id');
     table.string('text');
     table.boolean('complete');
 
-  }).then({} => {
+  }).then(() => {
 
     app.use('/todos', todos);
 
@@ -90,8 +90,7 @@ todos
       console.log(`Feathers server listening on port ${port}`);
     });
 
-  })
-
+  });
 ```
 
 You can run this example by using `node server` and going to [localhost:8080/todos](http://localhost:8080/todos). You should see an empty array. That's because you don't have any Todos yet but you now have full CRUD for your new todos service!

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ import rest from 'feathers-rest';
 import bodyParser from 'body-parser';
 import knexService from 'feathers-knex';
 
+// Initialize knex database adapter
 const knex = require('knex')({
   client: 'sqlite3',
   connection: {
@@ -44,18 +45,15 @@ const knex = require('knex')({
   }
 });
 
-// Clean up our data. This is optional and is here
-// because of our integration tests
-knex.schema.dropTableIfExists('todos').then(function() {
-  console.log('Dropped todos table');
-
-  // Initialize your table
-  return knex.schema.createTable('todos', function(table) {
-    console.log('Creating todos table');
-    table.increments('id');
-    table.string('text');
-    table.boolean('complete');
-  });
+// Create Knex Feathers service with a default page size of 2 items
+// and a maximum size of 4
+var todos = knexService({
+  Model: knex,
+  name: 'todos',
+  paginate: {
+    default: 2,
+    max: 4
+  }
 });
 
 // Create a feathers instance.
@@ -67,26 +65,33 @@ const app = feathers()
   // Turn on URL-encoded parser for REST services
   .use(bodyParser.urlencoded({ extended: true }));
 
-// Create Knex Feathers service with a default page size of 2 items
-// and a maximum size of 4
-app.use('/todos', knexService({
-  Model: knex,
-  name: 'todos',
-  paginate: {
-    default: 2,
-    max: 4
-  }
-}));
+// Initialize the database table with a schema
+// then mount the service and start the app
+todos
+  .init({}, function(table) {
 
-app.use(function(error, req, res, next){
-  res.json(error);
-});
+    //define your schema
+    debug(`created ${table} table`);
+    table.increments('id');
+    table.string('text');
+    table.boolean('complete');
 
-// Start the server.
-const port = 8080;
-app.listen(port, function() {
-  console.log(`Feathers server listening on port ${port}`);
-});
+  }).then({} => {
+
+    app.use('/todos', todos);
+
+    app.use(function(error, req, res, next){
+      res.json(error);
+    });
+
+    // Start the server.
+    const port = 8080;
+    app.listen(port, function() {
+      console.log(`Feathers server listening on port ${port}`);
+    });
+
+  })
+
 ```
 
 You can run this example by using `node server` and going to [localhost:8080/todos](http://localhost:8080/todos). You should see an empty array. That's because you don't have any Todos yet but you now have full CRUD for your new todos service!

--- a/example/app.js
+++ b/example/app.js
@@ -41,6 +41,7 @@ todos
     table.string('text');
     table.boolean('complete');
   }).then(() => {
+    console.log('/todos mounted');
     app.use('/todos', todos);
 
     app.use(function (error, req, res, next) {

--- a/example/app.js
+++ b/example/app.js
@@ -34,26 +34,19 @@ const app = feathers()
 // Initialize the database table with a schema
 // then mount the service and start the app
 todos
-  .init({}, function(table) {
-
-    //define your schema
+  .init({}, function (table) {
+    // define your schema
     console.log(`created ${table._tableName} table`);
     table.increments('id');
     table.string('text');
     table.boolean('complete');
-
   }).then(() => {
-
     app.use('/todos', todos);
 
-    app.use(function(error, req, res, next){
+    app.use(function (error, req, res, next) {
       res.json(error);
     });
-
-    // Start the server.
-    const port = 8080;
-    app.listen(port, function() {
-      console.log(`Feathers server listening on port ${port}`);
-    });
-
   });
+
+module.exports = app.listen(3030);
+console.log('Feathers Todo Knex service running on 127.0.0.1:3030');

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lib": "lib"
   },
   "dependencies": {
+    "debug": "^2.6.8",
     "feathers-errors": "^2.0.1",
     "feathers-query-filters": "^2.0.0",
     "is-plain-object": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "semistandard": "^11.0.0",
-    "sqlite3": "^3.1.0"
+    "sqlite3": "^3.1.8"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class Service {
     let k = this.knex;
     let table = this.table;
 
-    return k.schema.dropTableIfExists(table)
+    return k.schema.createTableIfNotExists(table)
       .then(function () {
         debug(`dropped ${table} table`);
         return k.schema.createTable(table, cb);

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,15 @@ class Service {
     let k = this.knex;
     let table = this.table;
 
-    return k.schema.createTableIfNotExists(table, cb);
+    return new Promise(function(fulfill, reject) {
+      k.schema.hasTable(table).then(exists => {
+        if (!exists) {
+          k.schema.createTable(table, cb).then(fulfill);
+        } else {
+          fulfill(null);
+        }
+      });
+    });
   }
 
   knexify (query, params, parentKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -57,12 +57,14 @@ class Service {
     let k = this.knex;
     let table = this.table;
 
-    return new Promise(function(fulfill, reject) {
+    return new Promise(function (resolve, reject) {
       k.schema.hasTable(table).then(exists => {
         if (!exists) {
-          k.schema.createTable(table, cb).then(fulfill);
+          debug(`creating ${table}`);
+          k.schema.createTable(table, cb).then(resolve);
         } else {
-          fulfill(null);
+          debug(`${table} already exists`);
+          resolve(null);
         }
       });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -57,11 +57,7 @@ class Service {
     let k = this.knex;
     let table = this.table;
 
-    return k.schema.createTableIfNotExists(table)
-      .then(function () {
-        debug(`dropped ${table} table`);
-        return k.schema.createTable(table, cb);
-      });
+    return k.schema.createTableIfNotExists(table, cb);
   }
 
   knexify (query, params, parentKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import isPlainObject from 'is-plain-object';
 import { errors } from 'feathers-errors';
 import errorHandler from './error-handler';
 
+const debug = require('debug')('feathers-knex');
+
 const METHODS = {
   $or: 'orWhere',
   $ne: 'whereNot',
@@ -49,6 +51,17 @@ class Service {
 
   extend (obj) {
     return Proto.extend(obj, this);
+  }
+
+  init (opts = {}, cb) {
+    let k = this.knex;
+    let table = this.table;
+
+    return k.schema.dropTableIfExists(table)
+      .then(function () {
+        debug(`dropped ${table} table`);
+        return k.schema.createTable(table, cb);
+      });
   }
 
   knexify (query, params, parentKey) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,37 +14,44 @@ const db = knex({
   }
 });
 
+const people = service({
+  Model: db,
+  name: 'people',
+  events: [ 'testing' ]
+});
+
+const peopleId = service({
+  Model: db,
+  id: 'customid',
+  name: 'people-customid',
+  events: [ 'testing' ]
+});
+
 function clean () {
-  return db.schema.dropTableIfExists('people')
-    .then(() => db.schema.dropTableIfExists('people-customid'))
-    .then(() =>
-      db.schema.createTable('people', table => {
-        table.increments('id');
-        table.string('name');
-        table.integer('age');
-        table.integer('time');
-        table.boolean('created');
-      }).then(() => db.schema.createTable('people-customid', table => {
-        table.increments('customid');
-        table.string('name');
-        table.integer('age');
-        table.integer('time');
-        table.boolean('created');
-      }))
-  );
+  return people.init({}, (table) => {
+    table.increments('id');
+    table.string('name');
+    table.integer('age');
+    table.integer('time');
+    table.boolean('created');
+    return table;
+  })
+  .then(() => {
+    return peopleId.init({}, (table) => {
+      table.increments('customid');
+      table.string('name');
+      table.integer('age');
+      table.integer('time');
+      table.boolean('created');
+      return table;
+    });
+  });
 }
 
 describe('Feathers Knex Service', () => {
-  const app = feathers().use('/people', service({
-    Model: db,
-    name: 'people',
-    events: [ 'testing' ]
-  })).use('/people-customid', service({
-    Model: db,
-    id: 'customid',
-    name: 'people-customid',
-    events: [ 'testing' ]
-  }));
+  const app = feathers()
+    .use('/people', people)
+    .use('people-customid', peopleId);
 
   before(clean);
   after(clean);


### PR DESCRIPTION
overview
---
This PR adds `service({}).init()` which returns a promise and gracefully degrades if database is already initialized.

tasks
---
- [x] add `init(opts={}, fn[table])`
- [x] update tests
- [x] implement in [generator](https://github.com/feathersjs/feathers-generator/pull/58)
- [x] update readme
- [x] update example