### PR TITLE
Convert total to integer for count() 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ class Service {
     if (filters.$limit === 0) {
       executeQuery = total => {
         return Promise.resolve({
-          total,
+          total: parseInt(total, 10),
           limit: filters.$limit,
           skip: filters.$skip || 0,
           data: []


### PR DESCRIPTION
### Summary

A small addendum to the fix for #108 that also converts total to an integer for count-only queries.

Not sure a PR was necessary for such a small change but meh -- feel free to axe it and commit directly :)

💛 feathers. Thanks for it!